### PR TITLE
gexiv2 instead of rexiv2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ edition = "2021"
 num = "0.4"
 image = "0.24.3"
 clap = { version = "3.2.22", features = ["derive"] }
-rexiv2 = "0.9.1"
+gexiv2-sys = "1.2"
+libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,3 @@ num = "0.4"
 image = "0.24.3"
 clap = { version = "3.2.22", features = ["derive"] }
 gexiv2-sys = "1.2"
-libc = "0.2"

--- a/src/png_writer.rs
+++ b/src/png_writer.rs
@@ -1,5 +1,5 @@
 use image;
-use rexiv2;
+extern crate gexiv2_sys as gexiv2;
 
 pub fn
 write_png
@@ -41,6 +41,7 @@ write_exif_description
 )
 {
 
+	/*
 	// Initialize library before it can be used
 	// Maybe not required at all?
 	// rexiv2::initialize().unwrap(); // .expect("Unable to initialize rexiv2");
@@ -54,5 +55,33 @@ write_exif_description
 			meta.save_to_file(&filename).expect("Could not write metadata to image file");
 		}
 	}
+	*/
 
+	let mut error: *mut gexiv2::GError = std::ptr::null_mut();
+	let path = std::ffi::CString::new(filename.as_bytes()).unwrap();
+
+	// Prepare EXIF tag & value
+	let tag = std::ffi::CString::new("Exif.Image.ImageDescription").unwrap();
+        let value = std::ffi::CString::new(description.as_bytes()).unwrap();
+	
+	unsafe
+	{
+		// Create new Metadata struct
+		let metadata = gexiv2::gexiv2_metadata_new();
+
+		// Read in existing image file
+		gexiv2::gexiv2_metadata_open_path(metadata, path.as_ptr(), &mut error);
+
+		// Add description to Metadata
+		let result: libc::c_int = gexiv2::gexiv2_metadata_set_tag_string(
+			metadata,
+			tag.as_ptr(),
+			value.as_ptr()
+		);
+
+		// Save Metadata to image file
+		gexiv2::gexiv2_metadata_save_file(metadata, path.as_ptr(), &mut error);
+		
+	}
+	
 }

--- a/src/png_writer.rs
+++ b/src/png_writer.rs
@@ -29,7 +29,7 @@ write_png
 		]);
 	}
 
-	image_buffer.save(&filename).unwrap();
+	image_buffer.save(filename).unwrap();
 	write_exif_description(filename, description);
 }
 
@@ -41,26 +41,11 @@ write_exif_description
 )
 {
 
-	/*
-	// Initialize library before it can be used
-	// Maybe not required at all?
-	// rexiv2::initialize().unwrap(); // .expect("Unable to initialize rexiv2");
-	
-	if let Ok(meta) = rexiv2::Metadata::new_from_path(&filename)
-	{
-		if meta
-		.set_tag_string("Exif.Image.ImageDescription", &description)
-		.is_ok()
-		{
-			meta.save_to_file(&filename).expect("Could not write metadata to image file");
-		}
-	}
-	*/
-
+	// Variables needed to interface gexiv2, which is a C library
 	let mut error: *mut gexiv2::GError = std::ptr::null_mut();
 	let path = std::ffi::CString::new(filename.as_bytes()).unwrap();
 
-	// Prepare EXIF tag & value
+	// Prepare EXIF tag & value as strings for C
 	let tag = std::ffi::CString::new("Exif.Image.ImageDescription").unwrap();
         let value = std::ffi::CString::new(description.as_bytes()).unwrap();
 	
@@ -70,17 +55,32 @@ write_exif_description
 		let metadata = gexiv2::gexiv2_metadata_new();
 
 		// Read in existing image file
-		gexiv2::gexiv2_metadata_open_path(metadata, path.as_ptr(), &mut error);
+		if 1 != gexiv2::gexiv2_metadata_open_path(metadata, path.as_ptr(), &mut error)
+		{
+			panic!("{}", std::ffi::CStr::from_ptr((*error).message)
+				.to_str()
+				.unwrap()
+			);
+		}
 
 		// Add description to Metadata
-		let result: libc::c_int = gexiv2::gexiv2_metadata_set_tag_string(
+		if 0 == gexiv2::gexiv2_metadata_set_tag_string(
 			metadata,
 			tag.as_ptr(),
 			value.as_ptr()
-		);
+		)
+		{
+			panic!("Error while setting description tag string");
+		}
 
 		// Save Metadata to image file
-		gexiv2::gexiv2_metadata_save_file(metadata, path.as_ptr(), &mut error);
+		if 1 != gexiv2::gexiv2_metadata_save_file(metadata, path.as_ptr(), &mut error)
+		{
+			panic!("{}", std::ffi::CStr::from_ptr((*error).message)
+				.to_str()
+				.unwrap()
+			);
+		}
 		
 	}
 	


### PR DESCRIPTION
Removed rexiv2 dependency and instead talk directly to gexiv2 for writing metadata. Reason is a problem with rexiv2 on windows (library uses unix-specific functionality not available under windows) which causes building to fail. As gexiv2 seems to be available under windows (using msys2), the project will hopefully be able to build again on all three platforms.